### PR TITLE
Bump endless-key-flatpak to v0.5

### DIFF
--- a/org.endlessos.Key.yaml
+++ b/org.endlessos.Key.yaml
@@ -73,4 +73,4 @@ modules:
     sources:
       - type: git
         url: https://github.com/endlessm/endless-key-flatpak.git
-        tag: v0.3
+        tag: v0.5


### PR DESCRIPTION
Bump endless-key-flatpak to v0.5

Fixes: https://github.com/endlessm/endless-key-flatpak/issues/50