### PR TITLE
Merge External Data Checker's successful PRs automatically

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,0 +1,3 @@
+{
+    "automerge-flathubbot-prs": true
+}


### PR DESCRIPTION
Merge External Data Checker's successful PRs automatically by setting "automerge-flathubbot-prs" in flathub.json.

Helps: https://github.com/flathub/org.endlessos.Key/issues/6