### PR TITLE
Bump org.freedesktop.Platform.ffmpeg-full to 23.08

### DIFF
--- a/org.endlessos.Key.yaml
+++ b/org.endlessos.Key.yaml
@@ -16,7 +16,7 @@ finish-args:
 
 add-extensions:
   org.freedesktop.Platform.ffmpeg-full:
-    version: '21.08'
+    version: '23.08'
     directory: lib/ffmpeg
     add-ld-path: '.'
     autodelete: false


### PR DESCRIPTION
Original org.freedesktop.Platform.ffmpeg-full//21.08 is end-of-life now. Bump it to version 23.08 against GNOME 45 runtime.