### PR TITLE
Update kolibri-app-desktop-xdg-plugin and Pillow

### DIFF
--- a/modules/python3-kolibri-app-desktop-xdg-plugin.json
+++ b/modules/python3-kolibri-app-desktop-xdg-plugin.json
@@ -2,26 +2,46 @@
     "name": "python3-kolibri-app-desktop-xdg-plugin",
     "buildsystem": "simple",
     "build-commands": [
-        "pip3 install --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} kolibri-app-desktop-xdg-plugin"
+        "pip3 install --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} --use-pep517 kolibri-app-desktop-xdg-plugin"
     ],
     "sources": [
         {
             "type": "file",
-            "url": "https://files.pythonhosted.org/packages/7d/2a/2fc11b54e2742db06297f7fa7f420a0e3069fdcf0e4b57dfec33f0b08622/Pillow-8.4.0.tar.gz",
-            "sha256": "b8e2f83c56e141920c39464b852de3719dfbfb6e3c99a2d8da0edf4fb33176ed",
+            "url": "https://files.pythonhosted.org/packages/bb/e1/ed2dd0850446b8697ad28d118df885ad04140c64ace06c4bd559f7c8a94f/setuptools-69.0.2-py3-none-any.whl",
+            "sha256": "1e8fdff6797d3865f37397be788a4e3cba233608e9b509382a2777d25ebde7f2",
+            "x-checker-data": {
+                "type": "pypi",
+                "name": "setuptools",
+                "packagetype": "bdist_wheel"
+            }
+        },
+        {
+            "type": "file",
+            "url": "https://files.pythonhosted.org/packages/c7/c3/55076fc728723ef927521abaa1955213d094933dc36d4a2008d5101e1af5/wheel-0.42.0-py3-none-any.whl",
+            "sha256": "177f9c9b0d45c47873b619f5b650346d632cdc35fb5e4d25058e09c9e581433d",
+            "x-checker-data": {
+                "type": "pypi",
+                "name": "wheel",
+                "packagetype": "bdist_wheel"
+            }
+        },
+        {
+            "type": "file",
+            "url": "https://files.pythonhosted.org/packages/80/d7/c4b258c9098b469c4a4e77b0a99b5f4fd21e359c2e486c977d231f52fc71/Pillow-10.1.0.tar.gz",
+            "sha256": "e6bf8de6c36ed96c86ea3b6e1d5273c53f46ef518a062464cd7ef5dd2cf92e38",
             "x-checker-data": {
                 "type": "pypi",
                 "name": "Pillow",
                 "versions": {
-                    ">=": "8.2.0",
-                    "<": "9.0.0"
+                    ">=": "10.1.0",
+                    "<": "11.0.0"
                 }
             }
         },
         {
             "type": "file",
-            "url": "https://files.pythonhosted.org/packages/3e/b8/46e65ec41b08c8f78a5e571357d6a0634187286f6ba558c447fb99f4512c/kolibri_app_desktop_xdg_plugin-1.1.4-py2.py3-none-any.whl",
-            "sha256": "16d16a21c55cae262dbf587e43815af1646b3b7dac70f07bf1d0c412833911aa",
+            "url": "https://files.pythonhosted.org/packages/44/01/a40f3823fc367731e5cd7a90306b0cc3af080b1e13f59fd66efb3ff7bec4/kolibri_app_desktop_xdg_plugin-1.2.0-py3-none-any.whl",
+            "sha256": "d689e7cdcdad49a2897fa1ce9069ff9d57e375c7918a4e5b27bb6fbe4d3e5859",
             "x-checker-data": {
                 "type": "pypi",
                 "name": "kolibri-app-desktop-xdg-plugin",


### PR DESCRIPTION
A new release of kolibri-app-desktop-xdg-plugin was made to update the Pillow dependency. The Pillow checker versions are updated here, so the next update should be automatic.