### PR TITLE
Revert "Add x-checker-data for kolibri-desktop-auth-plugin module"

### DIFF
--- a/modules/python3-kolibri-desktop-auth-plugin.json
+++ b/modules/python3-kolibri-desktop-auth-plugin.json
@@ -8,12 +8,7 @@
         {
             "type": "file",
             "url": "https://files.pythonhosted.org/packages/bc/fe/f9a5b62da8daf554eb5e7a28283cfb01f401618902c18012df0011585c7a/kolibri_desktop_auth_plugin-0.0.7-py2.py3-none-any.whl",
-            "sha256": "f1920b49fd0805fe45aa3024b047690d107617efb1932c0100860a156ab39448",
-            "x-checker-data": {
-                "type": "pypi",
-                "name": "kolibri-desktop-auth-plugin",
-                "packagetype": "bdist_wheel"
-            }
+            "sha256": "f1920b49fd0805fe45aa3024b047690d107617efb1932c0100860a156ab39448"
         }
     ]
 }


### PR DESCRIPTION
This reverts commit 122e10b726baa5b7f7cef5d050defcb4009d6c22.

We need this because I lazily released an end of life update to kolibri-desktop-auth-plugin which [removes all of its functionality and adds a data migration](https://github.com/endlessm/kolibri-desktop-auth-plugin/commit/34e3846db062c61a25a468fcbf0892db4384018c). Unfortunately, the Endless Key app isn't ready for that yet.