### PR TITLE
Disable flatpak-external-data-checker on flathub

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,0 +1,3 @@
+{
+  "disable-external-data-checker": true
+}


### PR DESCRIPTION
No one is processing the flatpak-external-data-checker generated PRs and they're just piling up. Disable flatpak-external-data-checker[1] until someone wants to take on reviewing the PRs.

1. https://docs.flathub.org/docs/for-app-authors/external-data-checker#disable